### PR TITLE
Issue 4: Add a button to initiate download as well as add resources link

### DIFF
--- a/AppClipped/AppClipped/App/Views/AppClipGeneratorView/AppClipGeneratorView.swift
+++ b/AppClipped/AppClipped/App/Views/AppClipGeneratorView/AppClipGeneratorView.swift
@@ -5,6 +5,7 @@
 //  Created by Matt Heaney on 01/03/2025.
 //
 
+import AppKit
 import SwiftUI
 
 struct AppClipGeneratorView: View {
@@ -155,12 +156,21 @@ struct AppClipGeneratorView: View {
                         ProgressView()
                             .scaleEffect(0.5)
                     }
-                }.frame(width: 200, height: 30)
+                }.frame(width: 250, height: 30)
             }
             .disabled(viewModel.state == .loading)
+            
+            Button {
+                if let url = URL(string: "https://download.developer.apple.com/Developer_Tools/App_Clip_Code_Generator/App_Clip_Code_Generator.dmg") {
+                    NSWorkspace.shared.open(url)
+                }
+            } label: {
+                Text("Download AppClipCodeGenerator")
+                    .frame(width: 250, height: 30)
+            }
 
             if viewModel.shouldShowInstallationMessage {
-                Text("AppClipCodeGenerator from Apple is required to use this tool. Please download it from https://developer.apple.com/download")
+                Text("AppClipCodeGenerator from Apple is required to use this tool. You can find it and more about App Clips at https://developer.apple.com/app-clips/resources/")
                     .font(.caption2)
             }
         }

--- a/AppClipped/AppClipped/App/Views/AppClipGeneratorView/AppClipGeneratorView.swift
+++ b/AppClipped/AppClipped/App/Views/AppClipGeneratorView/AppClipGeneratorView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 struct AppClipGeneratorView: View {
 
-    //MARK: Dependancies
+    //MARK: Dependencies
 
     @State var viewModel = AppClipGeneratorViewModel()
 

--- a/AppClipped/AppClipped/App/Views/AppClipGeneratorView/AppClipGeneratorViewModel.swift
+++ b/AppClipped/AppClipped/App/Views/AppClipGeneratorView/AppClipGeneratorViewModel.swift
@@ -11,7 +11,7 @@ import SwiftUI
 @Observable
 class AppClipGeneratorViewModel {
 
-    //MARK: Dependancies
+    //MARK: Dependencies
     let appClipToolManager = AppClipToolManager()
     let appClipCodeManager = AppClipCodeManager()
 


### PR DESCRIPTION
This PR aims to make downloading the AppClip tool provided by Apple easier by kicking off a URL that immediately initiates the download. Additionally, I swapped out the bottom link to the downloads page to instead feature the App Clip resources page provided by Apple, which also features a link to the tool.

Closes Issue #4 